### PR TITLE
link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ There are several options that can be passed in as a second parameter, like the 
 showError('This is an error shown without a timeout', { timeout: 0 })
 ```
 
-A full list of available options can be found in the documentation.
+A full list of available options can be found in the [documentation](https://nextcloud.github.io/nextcloud-dialogs/).


### PR DESCRIPTION
You could also add the documentation as "website" in this repository. Then this will be more present.

This may apply to other @nextcloud npm packages as well.