### PR TITLE
Toast: fix timeout and callback

### DIFF
--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -23,9 +23,9 @@ export interface ToastOptions {
 	 */
 	type?: ToastType|undefined;
 	/**
-	 * Provide a function that is called after the toast is shown
+	 * Provide a function that is called after the toast is removed
 	 */
-	onShow?: Function,
+	onRemove?: Function,
 	/**
 	 * Provide a function that is called when the toast is clicked
 	 */
@@ -47,7 +47,7 @@ export function showMessage(text: string, options?: ToastOptions): Toast {
 		timeout: 7,
 		isHTML: false,
 		type: undefined,
-		onShow: () => {},
+		onRemove: () => {},
 		onClick: () => {},
 		close: true
 	}, options)
@@ -63,7 +63,7 @@ export function showMessage(text: string, options?: ToastOptions): Toast {
 	const toast = Toastify({
 		text: text,
 		duration: options.timeout ? options.timeout * 1000 : null,
-		callback: options.onShow,
+		callback: options.onRemove,
 		onClick: options.onClick,
 		close: options.close,
 		gravity: 'top',

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -10,7 +10,7 @@ class ToastType {
 
 export interface ToastOptions {
 	/**
-	 * Defines the timeout after which the toast is closed. Set to 0 to have a persistent toast.
+	 * Defines the timeout after which the toast is closed. Set to -1 to have a persistent toast.
 	 */
 	timeout?: number;
 	/**


### PR DESCRIPTION
This PR contains two fixes:

## Timeout

The documentation for persistent toasts was wrong. Instead of using `timeout=0` you must use a negative number, e.g. `timeout=-1`. See also https://github.com/apvarun/toastify-js/pull/26 .

## Callback

Toastify-js has a parameter `callback`. This callback function is called when removing the Toast from DOM, see https://github.com/apvarun/toastify-js/blob/1.6.1/src/toastify.js#L233-L245 . Unfortunately, in @nextcloud/dialogs, this parameter was named `onShow` (see https://github.com/nextcloud/nextcloud-dialogs/blob/v1.1.0/lib/toast.ts#L66), which is very misleading. Therefore, this PR renames the parameter and updates the docs.