### PR TITLE
Make the body element the default Toast selector

### DIFF
--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -57,7 +57,8 @@ export function showMessage(text: string, options?: ToastOptions): Toast {
 		timeout: 7,
 		isHTML: false,
 		type: undefined,
-		selector: 'body-user',
+		// An undefined selector defaults to the body element
+		selector: undefined,
 		onRemove: () => { },
 		onClick: () => { },
 		close: true


### PR DESCRIPTION
Using `body-user` as the default selector caused the Toast to not be usable in guest pages without overriding the selector. An undefined selector selects the body element, so in practice the same element is still selected in logged in pages while making it usable by default in guest pages.

With shame I have to admit that I did not test this before sending the pull request. I just want to go to bed :-P So please test before approving ;-) Thanks!
