### PR TITLE
Allow passing 0 as duration for toasts

### DIFF
--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -71,10 +71,9 @@ export function showMessage(text: string, options?: ToastOptions): Toast {
 	}
 	let classes = options.type ?? ''
 
-
 	const toast = Toastify({
 		text: text,
-		duration: options.timeout ? options.timeout * 1000 : null,
+		duration: (options.timeout === null || options.timeout === undefined) ? null : options.timeout * 1000,
 		callback: options.onRemove,
 		onClick: options.onClick,
 		close: options.close,


### PR DESCRIPTION
Ref https://github.com/nextcloud/nextcloud-dialogs/pull/111#issuecomment-614196363

Again, didn't test. If anyone has an application that makes use of this, please give it a quick test.