### PR TITLE
Export default undo timeout and fix timeout unit

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/toast.ts:190
+#: lib/toast.ts:191
 msgid "Undo"
 msgstr ""

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/toast.ts:192
+#: lib/toast.ts:190
 msgid "Undo"
 msgstr ""

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export { FilePicker, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
-export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'
+export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from './toast'
+export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
 export { FilePicker, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
-export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'
+export { TOAST_UNDO_TIMEOUT, showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
 export { FilePicker, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
-export { TOAST_UNDO_TIMEOUT, showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'
+export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -36,7 +36,7 @@ export const TOAST_UNDO_TIMEOUT = 10000
 
 export interface ToastOptions {
 	/**
-	 * Defines the timeout after which the toast is closed. Set to -1 to have a persistent toast.
+	 * Defines the timeout in milliseconds after which the toast is closed. Set to -1 to have a persistent toast.
 	 */
 	timeout?: number
 
@@ -80,7 +80,7 @@ export interface ToastOptions {
  */
 export function showMessage(data: string|Node, options?: ToastOptions): Toast {
 	options = Object.assign({
-		timeout: 7,
+		timeout: 7000,
 		isHTML: false,
 		type: undefined,
 		// An undefined selector defaults to the body element
@@ -104,14 +104,9 @@ export function showMessage(data: string|Node, options?: ToastOptions): Toast {
 
 	const isNode = data instanceof Node
 
-	let timeout = null
-	if (options.timeout) {
-		timeout = options.timeout === -1 ? -1 : options.timeout * 1000
-	}
-
 	const toast = Toastify({
 		[!isNode ? 'text' : 'node']: data,
-		duration: timeout,
+		duration: options.timeout,
 		callback: options.onRemove,
 		onClick: options.onClick,
 		close: options.close,

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -33,6 +33,7 @@ class ToastType {
 }
 
 export const TOAST_UNDO_TIMEOUT = 10000
+export const TOAST_DEFAULT_TIMEOUT = 7000
 
 export interface ToastOptions {
 	/**
@@ -80,7 +81,7 @@ export interface ToastOptions {
  */
 export function showMessage(data: string|Node, options?: ToastOptions): Toast {
 	options = Object.assign({
-		timeout: 7000,
+		timeout: TOAST_DEFAULT_TIMEOUT,
 		isHTML: false,
 		type: undefined,
 		// An undefined selector defaults to the body element

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -32,6 +32,8 @@ class ToastType {
 	static readonly UNDO = 'toast-undo';
 }
 
+export const TOAST_UNDO_TIMEOUT = 10000
+
 export interface ToastOptions {
 	/**
 	 * Defines the timeout after which the toast is closed. Set to -1 to have a persistent toast.
@@ -180,7 +182,7 @@ export function showUndo(text: string, onUndo: Function, options?: ToastOptions)
 
 	options = Object.assign(options || {}, {
 		// force 10 seconds of timeout
-		timeout: 10000,
+		timeout: TOAST_UNDO_TIMEOUT,
 		// remove close button
 		close: false
 	})

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -34,6 +34,7 @@ class ToastType {
 
 export const TOAST_UNDO_TIMEOUT = 10000
 export const TOAST_DEFAULT_TIMEOUT = 7000
+export const TOAST_PERMANENT_TIMEOUT = -1
 
 export interface ToastOptions {
 	/**


### PR DESCRIPTION
Fix timeout unit to use the same as toastify.
We also get closer to the syntax of `setTimeout`, let's not mix units in js :see_no_evil: 
___
Allows us to define fancy setTimeouts

```js
import { showUndo, TOAST_UNDO_TIMEOUT } from '@nextcloud/dialogs'

// DELETION
onDeleteWithUndo() {
	this.deleted = true
	const timeOutDelete = setTimeout(this.onDelete, TOAST_UNDO_TIMEOUT)
	showUndo(t('comments', 'Comment deleted'), () => {
		clearTimeout(timeOutDelete)
		this.deleted = false
	})
},
```