### PR TITLE
Add dark mode close button

### DIFF
--- a/styles/close-dark.svg
+++ b/styles/close-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16">
+  <path d="M14 12.3L12.3 14 8 9.7 3.7 14 2 12.3 6.3 8 2 3.7 3.7 2 8 6.3 12.3 2 14 3.7 9.7 8z" style="fill-opacity:1;fill:#ffffff"/>
+</svg>

--- a/styles/toast.scss
+++ b/styles/toast.scss
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 // using a different class than server
 // remember to import this scss file into your app
 .toastify.dialogs {
@@ -98,5 +98,17 @@
 
 	&.toast-undo {
 		border-left: 3px solid var(--color-success);
+	}
+}
+
+/* dark theme overrides */
+.theme--dark {
+	.toastify.dialogs {
+		.toast-close {
+			/* close icon style */
+			&.toast-close {
+				background-image: url('./close-dark.svg');
+			}
+		}
 	}
 }


### PR DESCRIPTION
Because before this it was black on black and not visible.

Regular:
<img width="224" alt="image" src="https://user-images.githubusercontent.com/277525/96554444-d4e41f80-12b6-11eb-82fa-2d7661e89383.png">

Hover:
<img width="224" alt="image" src="https://user-images.githubusercontent.com/277525/96554477-e1687800-12b6-11eb-8e87-8f2a12578d65.png">

