### PR TITLE
Increase toast z-index above modal dialogs

### DIFF
--- a/styles/toast.scss
+++ b/styles/toast.scss
@@ -32,7 +32,7 @@
 	padding-right: 34px;
 	margin-top: 45px;
 	position: fixed;
-	z-index: 9000;
+	z-index: 10100;
 	border-radius: var(--border-radius);
 
 	.toast-undo-button,


### PR DESCRIPTION
Because our modals are on 1000 and we want to see the toast notifications higher: https://github.com/nextcloud/nextcloud-vue/blob/master/src/components/Modal/Modal.vue#L496