### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,17 +16,17 @@ const packageJson = require("./package.json");
 const translations = fs
 	.readdirSync('./l10n')	
 	.filter(name => name !== 'messages.pot' && name.endsWith('.pot'))
-	.map(file => {	
-		const path = './l10n/' + file	
-		const locale = file.substr(0, file.length - '.pot'.length)	
+	.map(file => {
+		const path = './l10n/' + file
+		const locale = file.slice(0, -'.pot'.length)
 
 
 		const po = fs.readFileSync(path)	
 		const json = gettextParser.po.parse(po)	
-		return {	
-			locale,	
-			json,	
-		}	
+		return {
+			locale,
+			json,
+		}
 	})
 
 export default {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.