### PR TITLE
Export FilePickerType enum

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
-export { FilePicker, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
+export { FilePicker, FilePickerType, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
 export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from './toast'
 export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'


### PR DESCRIPTION
Allow users of this package to use the more easily grokked
```ts
getFilePickerBuilder('Choose a file or folder to transfer')
	.setType(FilePickerType.Choose)
	.build()
```
instead of
```ts
getFilePickerBuilder('Choose a file or folder to transfer')
	.setType(1)
	.build()
```