### PR TITLE
Fix dark mode with Nextcloud 25

### DIFF
--- a/styles/toast.scss
+++ b/styles/toast.scss
@@ -28,7 +28,7 @@
 	background-color: var(--color-main-background);
 	color: var(--color-main-text);
 	box-shadow: 0 0 6px 0 var(--color-box-shadow);
-	padding: 0px 12px;
+	padding: 0 12px;
 	margin-top: 45px;
 	position: fixed;
 	z-index: 10100;
@@ -57,9 +57,23 @@
 
 		// icon styling
 		&.toast-close {
-			background-image: url('./close.svg');
-			text-indent: 200%;
+			text-indent: 0;
 			opacity: .4;
+			border: none;
+			min-height: 44px;
+			margin-left: 10px;
+			font-size: 0;
+
+			/* dark theme overrides for Nextcloud 25 and later */
+			&::before {
+				background-image: url('./close.svg');
+				content: ' ';
+				filter: var(--background-invert-if-dark);
+
+				display: inline-block;
+				width: 16px;
+				height: 16px;
+			}
 		}
 
 		&.toast-undo-button {
@@ -106,12 +120,12 @@
 	}
 }
 
-/* dark theme overrides */
+/* dark theme overrides for Nextcloud 24 and earlier */
 .theme--dark {
 	.toastify.dialogs {
 		.toast-close {
 			/* close icon style */
-			&.toast-close {
+			&.toast-close::before {
 				background-image: url('./close-dark.svg');
 			}
 		}


### PR DESCRIPTION
Fix #629 

### Before
* 24 👍🏼 
* 25
    - Normal
![Bildschirmfoto vom 2022-07-21 11-21-41](https://user-images.githubusercontent.com/213943/180192997-54148792-5707-4bdb-a32b-f99762f928ec.png)
    - Keyboard hover
![Bildschirmfoto vom 2022-07-21 11-21-48](https://user-images.githubusercontent.com/213943/180192992-668f07ec-ac3b-4927-a89c-5c3408a384ca.png)



### After

Mode | Nextcloud 24 | Nextcloud 25 (Sorry for the 120% zoom)
---|---|---
Bright mode | ![Bildschirmfoto vom 2022-07-21 12-23-36](https://user-images.githubusercontent.com/213943/180192446-2d5a7b23-d6f6-4570-9e5a-46503077a00b.png) | ![Bildschirmfoto vom 2022-07-21 12-09-18](https://user-images.githubusercontent.com/213943/180192436-241d2471-ec98-4c69-9e34-a73795f95e42.png)
Bright mode keyboard hover | ![Bildschirmfoto vom 2022-07-21 12-23-27](https://user-images.githubusercontent.com/213943/180192448-7f6dbc0d-5f21-478e-849d-16d7a6c39488.png) | ![Bildschirmfoto vom 2022-07-21 12-09-10](https://user-images.githubusercontent.com/213943/180192430-e5630aee-00a9-41ca-b9e9-2d679435a556.png)
Dark mode | ![Bildschirmfoto vom 2022-07-21 12-23-16](https://user-images.githubusercontent.com/213943/180192442-60e96119-dc08-4381-a03d-0724f3478bb1.png) | ![Bildschirmfoto vom 2022-07-21 12-09-23](https://user-images.githubusercontent.com/213943/180192437-1ed13f54-4a9a-4b32-9208-3fa082934921.png)
Dark mode keyboard hover | ![Bildschirmfoto vom 2022-07-21 12-23-21](https://user-images.githubusercontent.com/213943/180192443-d127d582-a81f-4bea-b855-1f49a133cf9e.png) | ![Bildschirmfoto vom 2022-07-21 12-09-33](https://user-images.githubusercontent.com/213943/180192438-a72907b4-a713-43d7-910e-22e3dacd583d.png)

