### PR TITLE
Do not change css class names when building

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,8 +15,6 @@ import BabelLoaderExcludeNodeModulesExcept from 'babel-loader-exclude-node-modul
 import { DEFAULT_EXTENSIONS } from '@babel/core'
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx']
 
-const packageJson = require('./package.json');
-
 const translations = fs
 	.readdirSync('./l10n')	
 	.filter(name => name !== 'messages.pot' && name.endsWith('.pot'))
@@ -65,13 +63,12 @@ export default [
 	{
 		input: 'styles/toast.scss',
 		output: {
-			file: 'dist/index.css',
-			format: 'esm',
+			file: 'dist/index.css'
 		},			
 		plugins: [
 			postcss({
-				modules: true,
 				extract: true,
+				sourceMap: true,
 				plugins: [
 					postcssurl({
 						url: 'inline',


### PR DESCRIPTION
Glad we did some beta lol, it seems module do some weird stuff

| Before | After |
|:---------:|:------:|
|![image](https://user-images.githubusercontent.com/14975046/198561222-9132d459-69e8-451f-9a16-68f64037cf2f.png)|![image](https://user-images.githubusercontent.com/14975046/198561070-ee72c93b-ed03-419c-892a-bcf6ab6d532f.png)|

Ref https://github.com/nextcloud/server/pull/34868