### PR TITLE
4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.0.0 (2023-02-13)
+
+### :boom: Breaking changes
+
+Styles need to be imported differently compared to v3.2.0. Make sure to import them from `dist/index.css`:
+
+	import '@nextcloud/dialogs/dist/index.css'
+
+
+### :rocket: Enhancement
+* [#577](https://github.com/nextcloud/nextcloud-dialogs/pull/577) Add filepicker filter ([@Pytal](https://github.com/Pytal))
+
+### Committers: 2
+- Ferdinand Thiessen ([@susnux](https://github.com/susnux))
+- [@Pytal](https://github.com/Pytal)
+
+
 ## [v4.0.0-beta.2](https://github.com/nextcloud/nextcloud-dialogs/tree/v4.0.0-beta.2) (2022-11-02)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-dialogs/compare/v4.0.0-beta.1...v4.0.0-beta.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0",
   "description": "",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
[4.0.0-beta.2](https://www.npmjs.com/package/@nextcloud/dialogs/v/4.0.0-beta.2) has been released 3 months ago but there never was a stable release.

Contributes to https://github.com/nextcloud/server/issues/36384