### PR TITLE
Fix package resolving in webpack projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "4.0.0",
   "description": "",
   "types": "dist/index.d.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.js"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     },
     "./dist/index.css": {
       "import": "./dist/index.css",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,12 +36,12 @@ export default [
 		input: 'lib/index.ts',
 		output: [
 			{
-				file: 'dist/index.js',
+				file: 'dist/index.cjs',
 				format: 'cjs',
 				sourcemap: true
 			},
 			{
-				file: 'dist/index.es.js',
+				file: 'dist/index.mjs',
 				format: 'esm',
 				sourcemap: true
 			}


### PR DESCRIPTION
Currently the *4.0.0* release can not be used with webpack projects, because they will throw:
`ReferenceError: exports is not defined`.

Webpack tries to resolve the import of `@nextcloud/dialogs` to `node_modules/@nextcloud/dialogs/dist/index.js`.
This is a commonjs file, but webpack expects an esm file, so `exports` is not defined.

I guess this happens because `dialogs` has its type set to `module´ so every `.js` file within will be handled as esm.

So to fix this we need to explicitly name commonjs files `.cjs`.

---
I noticed this issue when trying to use `@nextcloud/vue 7.6.0` which depends on dialogs version `4.0.0`.