### PR TITLE
fix: Setup Typescript for node16 resolution of `@nextcloud/l10n`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-export { FilePicker, FilePickerType, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
-export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from './toast'
-export { TOAST_ARIA_LIVE_OFF, TOAST_ARIA_LIVE_POLITE, TOAST_ARIA_LIVE_ASSERTIVE } from './toast'
-export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'
+export { FilePicker, FilePickerType, FilePickerBuilder, getFilePickerBuilder } from './filepicker.js'
+export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from './toast.js'
+export { TOAST_ARIA_LIVE_OFF, TOAST_ARIA_LIVE_POLITE, TOAST_ARIA_LIVE_ASSERTIVE } from './toast.js'
+export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast.js'

--- a/lib/l10n.ts
+++ b/lib/l10n.ts
@@ -1,4 +1,4 @@
-import { getGettextBuilder } from '@nextcloud/l10n/dist/gettext'
+import { getGettextBuilder } from '@nextcloud/l10n/gettext'
 
 const gtBuilder = getGettextBuilder()
 	.detectLocale()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "outDir": "./dist",
       "lib": ["ES5", "ES6", "dom"],
       "module": "ESNext",
-      "moduleResolution": "node",
+      "moduleResolution": "node16",
       "rootDir": "lib/",
       "sourceMap": true,
       "target": "ES2015"


### PR DESCRIPTION
Fixes this error when building:

```
(!) Plugin node-resolve: Could not resolve import "@nextcloud/l10n/dist/gettext" in nextcloud-dialogs/lib/l10n.ts using exports defined in nextcloud-dialogs/node_modules/@nextcloud/l10n/package.json.
(!) Unresolved dependencies
```