### PR TITLE
fix: Make sure dependencies are external

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ export default {
             "@babel/env",
             {
                 useBuiltIns: "usage",
-                corejs: "3.0.0",
+                corejs: "3",
             },
         ],
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,10 @@ const packageJson = JSON.parse(
 	)
 )
 
-const externals = [...Object.keys(packageJson?.dependencies || {}), ...Object.keys(packageJson?.peerDependencies || {})]
+const externals = [
+	...Object.keys(packageJson?.dependencies || {}),
+	...Object.keys(packageJson?.peerDependencies || {})
+].map(packageName => new RegExp(`^${packageName}`))
 
 const translations = fs
 	.readdirSync('./l10n')	


### PR DESCRIPTION
Rollup does check strings for full match, so transforming our dependencies list to RegExp will work even with imports like `import 'core-js/foo/bar`.

Before: `1'824 kB` (yes 1.8 MiB)
After: `237 kB`