### PR TITLE
Fix package exports for Typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@nextcloud/dialogs",
   "version": "4.0.1",
-  "description": "",
+  "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
Ensure the package can be used with `node16` or `nodeNext` module resolution by adding the types to the `exports` section.