### PR TITLE
Update CI for l10n extraction to use node version from `package.json`

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -9,10 +9,17 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Set up Node
-      uses: actions/setup-node@v1
+    - name: Read package.json node and npm engines version
+      uses: skjnldsv/read-package-engines-version-actions@0ce2ed60f6df073a62a77c0a4958dd0fc68e32e7 # v2.1
+      id: versions
       with:
-        node-version: 12.x
+        fallbackNode: '^16'
+        fallbackNpm: '^7'
+
+    - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+      with:
+        node-version: ${{ steps.versions.outputs.nodeVersion }}
 
     - name: npm install
       run: npm ci


### PR DESCRIPTION
CI script is not from organization so was not updated, I do not think we need any node 12 scripts anymore.