### PR TITLE
Prepare release of version 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.1.0 (2023-06-23)
+
+### :bug: Fixed bugs
+
+- Make sure Typescript projects with `node16` module resolution can import the package [\#845](https://github.com/nextcloud/nextcloud-dialogs/pull/845) ([@susnux](https://github.com/susnux))
+- Ensure all package dependencies are external [\#843](https://github.com/nextcloud/nextcloud-dialogs/pull/843) ([@susnux](https://github.com/susnux))
+
+### Changed
+
+- Update Node engines to next LTS (version 20)
+- Translation updates
+- Dependency updates
+
 ## v4.0.1 (2023-02-16)
 
 #### :rocket: Enhancement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^2.1.0",
@@ -38,8 +38,8 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
       }
     },
     "../rollup-plugin-baked-env": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Would be great to have the Typescript fixes released, so I prepared the changelog and bumped the package version.

If accepted can someone with admin rights spin the npm release?