### PR TITLE
chore: Do not bundle `core-js` polyfills already included in server core

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,8 +4,7 @@ export default {
         [
             "@babel/env",
             {
-                useBuiltIns: "usage",
-                corejs: "3",
+                useBuiltIns: false,
             },
         ],
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.31.1",
         "toastify-js": "^1.12.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/typings": "^1.7.0",
-    "core-js": "^3.31.1",
     "toastify-js": "^1.12.0"
   },
   "files": [


### PR DESCRIPTION
We do not need to include core-js polyfills, they are already bundled with the server core.