### PR TITLE
fix: Add workflow to ignore node ci when unrelated

### DIFF
--- a/.github/workflows/node-when-unrelated.yml
+++ b/.github/workflows/node-when-unrelated.yml
@@ -1,0 +1,44 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# Use node together with node-when-unrelated to make eslint a required check for GitHub actions
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: Node
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'appinfo/info.xml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '**.js'
+      - '**.ts'
+      - '**.vue'
+  push:
+    branches:
+      - main
+      - master
+      - stable*
+
+concurrency:
+  group: node-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    permissions:
+      contents: none
+
+    runs-on: ubuntu-latest
+
+    name: node
+    steps:
+      - name: Skip
+        run: 'echo "No JS/TS files changed, skipped Node"'


### PR DESCRIPTION
CI on this does never finish: https://github.com/nextcloud/nextcloud-dialogs/pull/868

So just ignore node when it is not related.