### PR TITLE
chore: prepare stable v7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 
 ### Added
 * feat: add guest auth prompt [\#1760](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1760) \([backportbot](https://github.com/backportbot)\)
+* feat(ConflictPicker): move conflict picker dialog from `@nextcloud/upload` [\#1971](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1971) \([susnux](https://github.com/susnux)\)
+* feat(dialogs): allow to quickly show a dialog [\#1986](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1986) \([susnux](https://github.com/susnux)\)
 
 ### Fixed
 * fix(FilePickerBuilder): correctly return array / plain value depending on multiselect [\#1775](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1775) \([susnux](https://github.com/susnux)\)
@@ -51,6 +53,7 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 * style(toast): adjust colors for Nextcloud 32 [\#1912](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1912) \([Antreesy](https://github.com/Antreesy)\)
 * fix(guestName): limit length to 64 characters [\#1915](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1915) \([max-nextcloud](https://github.com/max-nextcloud)\)
 * fix(FilePicker): make move primary and copy secondary [\#1933](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1933) \([susnux](https://github.com/susnux)\)
+* fix: allow dismiss the undo toast [\#1944](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1944) \([luka-nextcloud](https://github.com/luka-nextcloud)\)
 
 ### Changed
 * chore: update to ESLint v9 and apply new rules [\#1753](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1753) \([susnux](https://github.com/susnux)\)
@@ -62,6 +65,8 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 * refactor: do not use Node internals but @nextcloud/paths package [\#1752](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1752) \([susnux](https://github.com/susnux)\)
 * Updates for project Nextcloud dialogs library by @transifex-integration[bot] 
 * chore(deps): @nextcloud family + various upgrades [\#1905](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1905) \([skjnldsv](https://github.com/skjnldsv)\)
+* chore: fix node version for dependabot [\#1960](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1960) \([susnux](https://github.com/susnux)\)
+* chore(dialogs)!: remove deprecated `setHTML` method [\#1985](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1985) \([susnux](https://github.com/susnux)\)
 
 ## [v6.3.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.3.1...v6.3.2)
 ### 🐛 Fixed bugs

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ npm i -S @nextcloud/dialogs
 ```
 
 ### Version compatibility
-Since version 4.2 this package provides a Vue.js based file picker, so this package depends on `@nextcloud/vue`.
-So to not introduce style collisions stick with the supported versions:
 
 | `@nextcloud/dialogs` | maintained | `@nextcloud/vue` dependency |   Nextcloud server version |
 |----------------------|------------|-----------------------------|----------------------------|
-|                 7.x  |         ✅ |                9.x (Vue 3)¹ | Nextcloud 30 and newer     |
-|                 6.x  |         ✅ |                        8.x  | Nextcloud 29 and newer     |
+|                 7.x  |         ✅ |                9.x (Vue 3)¹ | Nextcloud 31 and newer     |
+|                 6.x  |         ✅ |                        8.x  | Nextcloud 29, 30, 31, 32   |
 |                 5.x  |         ❌ |                        8.x  | Nextcloud 28, 29, 30       |
-|                 4.2+ |         ❌ |                        7.12 | Nextcloud 25, 26, 27, 27.1 |
-|                 4.1  |         ❌ |                       *any* |  *any*                     |
+|                 4.2+ |         ❌ |                       7.12² | Nextcloud 25, 26, 27, 27.1 |
+|                 4.1  |         ❌ |                       *any* | *any up to Nextcloud 30*   |
 
 ¹: In version 7.x the `@nextcloud/vue` dependency is moved to `dependencies` so you can also use this library
 with an old version of `@nextcloud/vue` in your app dependencies if your app still uses Vue 2.
-Note that this might increase the bundled app size.
+Note that this might increase the bundled app size. 
 If your app also already uses `@nextcloud/vue` version 9.x and Vue 3 then the bundle size will not increase.
+
+²: Since version 4.2 this package provides a Vue.js based file picker, so this package depends on `@nextcloud/vue`.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0-rc.3",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "7.0.0-rc.3",
+      "version": "7.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0-rc.3",
+  "version": "7.0.0",
   "description": "Nextcloud dialog helpers",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
- [x] best to include https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1986

---

## Changes since last RC
### 🚀 Enhancements
* feat(ConflictPicker): move conflict picker dialog from `@nextcloud/upload` by @susnux in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1971
* feat(dialogs): allow to quickly show a dialog #1986 

### Fixed
* fix: allow dismiss the undo toast by @luka-nextcloud in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1944

### Changes
* chore: fix node version for dependabot by @susnux in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1960
* chore(dialogs)!: remove deprecated `setHTML` method by @susnux in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1985
