### PR TITLE
chore: prepare v7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.0.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v7.0.0...v7.0.1)
+### Fixed
+* fix: export `showConfirmation` method [\#2029](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2029) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* docs: adjust changes link for v7.0.0 [\#2008](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2008) \([susnux](https://github.com/susnux)\)
+* Updated translations
+
 ## [v7.0.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.3.2...v7.0.0)
 
 ### Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Nextcloud dialog helpers",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## [v7.0.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v7.0.0...v7.0.1)
### Fixed
* fix: export `showConfirmation` method [\#2029](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2029) \([susnux](https://github.com/susnux)\)

### Changed
* docs: adjust changes link for v7.0.0 [\#2008](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2008) \([susnux](https://github.com/susnux)\)
* Updated translations
