### PR TITLE
fix(FileListRow): `enter-directory` event name

### DIFF
--- a/lib/components/FilePicker/FileListRow.spec.ts
+++ b/lib/components/FilePicker/FileListRow.spec.ts
@@ -14,7 +14,7 @@ import FileListRow from './FileListRow.vue'
 import { nextTick } from 'vue'
 
 type SubmitAction = (wrapper: VueWrapper<any>) => Promise<void>
-type ElementEvent = { 'update:selected': boolean | undefined, enterDirectory: Folder | undefined }
+type ElementEvent = { 'update:selected': boolean | undefined, 'enter-directory': Folder | undefined }
 
 async function clickCheckboxAction(wrapper: VueWrapper<any>) {
 	wrapper.find('input[type="checkbox"]').trigger('click')
@@ -91,17 +91,17 @@ const defaultOptions = {
 
 const noEmits = {
 	'update:selected': undefined,
-	enterDirectory: undefined,
+	'enter-directory': undefined,
 }
 
 const selectNode = {
 	'update:selected': true,
-	enterDirectory: undefined,
+	'enter-directory': undefined,
 }
 
 const navigateToFolder = {
 	'update:selected': undefined,
-	enterDirectory: folder,
+	'enter-directory': folder,
 }
 
 describe('FilePicker: FileListRow', () => {

--- a/lib/components/FilePicker/FileListRow.vue
+++ b/lib/components/FilePicker/FileListRow.vue
@@ -114,7 +114,7 @@ function toggleSelected() {
 function handleClick() {
 	if (isDirectory.value) {
 		if (isNavigatable.value) {
-			emit('enterDirectory', props.node)
+			emit('enter-directory', props.node)
 		}
 	} else {
 		toggleSelected()


### PR DESCRIPTION
Was wrongly changed by https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2051
