### PR TITLE
fix(conflict-picker): use sub-path import to only import needed parts

### DIFF
--- a/lib/conflict-picker.ts
+++ b/lib/conflict-picker.ts
@@ -5,7 +5,7 @@
 
 import type { INode } from '@nextcloud/files'
 
-import { spawnDialog } from '@nextcloud/vue'
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { defineAsyncComponent } from 'vue'
 
 export type ConflictInput = File | FileSystemEntry | INode


### PR DESCRIPTION
- resolves https://github.com/nextcloud-libraries/nextcloud-dialogs/issues/2028