### PR TITLE
fix(filepicker): use proper folder icons

### DIFF
--- a/lib/components/FilePicker/FilePreview.vue
+++ b/lib/components/FilePicker/FilePreview.vue
@@ -26,7 +26,7 @@
 <script setup lang="ts">
 import type { INode } from '@nextcloud/files'
 
-import { mdiAccountPlus, mdiGroup, mdiLink, mdiLock, mdiNetwork, mdiTag } from '@mdi/js'
+import { mdiAccountGroupOutline, mdiAccountPlus, mdiKey, mdiLink, mdiNetworkOutline, mdiTagOutline } from '@mdi/js'
 import { FileType } from '@nextcloud/files'
 import { ShareType } from '@nextcloud/sharing'
 import { computed, ref, toRef } from 'vue'
@@ -65,12 +65,12 @@ const folderDecorationIcon = computed(() => {
 
 	// Encrypted folders
 	if (props.node.attributes?.['is-encrypted'] === 1) {
-		return mdiLock
+		return mdiKey
 	}
 
 	// System tags
 	if (props.node.attributes?.['is-tag']) {
-		return mdiTag
+		return mdiTagOutline
 	}
 
 	// Link and mail shared folders
@@ -87,9 +87,9 @@ const folderDecorationIcon = computed(() => {
 	switch (props.node.attributes?.['mount-type']) {
 		case 'external':
 		case 'external-session':
-			return mdiNetwork
+			return mdiNetworkOutline
 		case 'group':
-			return mdiGroup
+			return mdiAccountGroupOutline
 		case 'shared':
 			return mdiAccountPlus
 	}


### PR DESCRIPTION
We need AccountGroup instead of just Group (wrong icon). Also its the key icon instead of the lock icon for encryption (to be inline with files app).

Also use outlines icons for https://github.com/nextcloud/server/issues/56345