### PR TITLE
chore: prepare v6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v6.4.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.3.2...v6.4.0)
+## [v6.4.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.4.1...v6.4.2)
+### 🐛 Fixed bugs
+* fix(filepicker): use `@nextcloud/files` for name validation [\#2161](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2161)
+* fix(filepicker): use proper folder icons [\#2181](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2181)
+* fix: always use the node `displayname` prop [\#2182](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2182) \([susnux](https://github.com/susnux)\)
+
+### Other Changes
+* refactor: use `@nextcloud/paths` instead of NodeJS `path` [\#2177](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2177) \([susnux](https://github.com/susnux)\)
+* ci: update workflows from organization [\#2178](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2178) \([susnux](https://github.com/susnux)\)
+
+## [v6.4.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.4.0...v6.4.1)
 ### 🐛 Fixed bugs
 * fix(FileListRow): enter-directory event name [\#2059](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2059) \([artonge](https://github.com/artonge)\)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v6.4.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.4.1...v6.4.2)
### 🐛 Fixed bugs
* fix(filepicker): use `@nextcloud/files` for name validation [\#2161](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2161)
* fix(filepicker): use proper folder icons [\#2181](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2181)
* fix: always use the node `displayname` prop [\#2182](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2182) \([susnux](https://github.com/susnux)\)

### Other Changes
* refactor: use `@nextcloud/paths` instead of NodeJS `path` [\#2177](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2177) \([susnux](https://github.com/susnux)\)
* ci: update workflows from organization [\#2178](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2178) \([susnux](https://github.com/susnux)\)
