### PR TITLE
fix(filepicker): Round previews in filepicker dialog

### DIFF
--- a/lib/components/FilePicker/FileListIcon.module.scss
+++ b/lib/components/FilePicker/FileListIcon.module.scss
@@ -14,6 +14,7 @@
 	min-height: 32px;
 	background-repeat: no-repeat;
 	background-size: contain;
+	border-radius: var(--border-radius-small);
 	// for the fallback
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
Add our standard border-radius, just like in the file list in Files. :)

Before | After 
-|-
<img width="1741" height="1003" alt="Screenshot From 2026-04-30 13-57-43" src="https://github.com/user-attachments/assets/94736b09-23f0-44bd-9d37-0ed1c7cb00ab" />|<img width="1741" height="1003" alt="Screenshot From 2026-04-30 13-57-13" src="https://github.com/user-attachments/assets/e85ea56e-2483-46f8-a528-aa92a1d729f8" />
