### PR TITLE
Simplify the file conflict dialog

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -17,17 +17,10 @@ msgstr ""
 msgid "\"{segment}\" is a reserved name and not allowed."
 msgstr ""
 
-msgid "%n file conflict"
-msgid_plural "%n files conflict"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "%n file conflict in {dirname}"
-msgid_plural "%n file conflicts in {dirname}"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "All files"
+msgstr ""
+
+msgid "An item with the same name already exists in {dirname}."
 msgstr ""
 
 msgid "Cancel"
@@ -83,6 +76,12 @@ msgstr ""
 msgid "Error: {message}"
 msgstr ""
 
+msgid "Existing files"
+msgstr ""
+
+msgid "Existing files and folders will be deleted if not selected. If both are chosen, they will be renamed."
+msgstr ""
+
 msgid "Existing version"
 msgstr ""
 
@@ -110,9 +109,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-msgid "If you select both versions, the incoming file will have a number added to its name."
-msgstr ""
-
 msgid "Info: {message}"
 msgstr ""
 
@@ -120,6 +116,12 @@ msgid "Invalid folder name."
 msgstr ""
 
 msgid "Invalid name."
+msgstr ""
+
+msgid "Items with the same name already exist in {dirname}, select which to keep."
+msgstr ""
+
+msgid "Keep both"
 msgstr ""
 
 msgid "Last modified date unknown"
@@ -152,6 +154,9 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+msgid "New files"
+msgstr ""
+
 msgid "New folder"
 msgstr ""
 
@@ -176,19 +181,22 @@ msgstr ""
 msgid "Recent"
 msgstr ""
 
+msgid "Replace"
+msgstr ""
+
 msgid "Select all checkboxes"
 msgstr ""
 
 msgid "Select all entries"
 msgstr ""
 
-msgid "Select all existing files"
-msgstr ""
-
-msgid "Select all new files"
-msgstr ""
-
 msgid "Select entry"
+msgstr ""
+
+msgid "Select file to keep"
+msgstr ""
+
+msgid "Select files to keep"
 msgstr ""
 
 msgid "Select the row for {nodename}"
@@ -201,9 +209,6 @@ msgid "Skip %n file"
 msgid_plural "Skip %n files"
 msgstr[0] ""
 msgstr[1] ""
-
-msgid "Skip this file"
-msgstr ""
 
 msgid "Submit name"
 msgstr ""
@@ -220,16 +225,13 @@ msgstr ""
 msgid "Warning: {message}"
 msgstr ""
 
-msgid "When an incoming folder is selected, any conflicting files within it will also be overwritten."
+msgid "When a new folder is selected, any conflicting files within it will also be overwritten."
 msgstr ""
 
-msgid "When an incoming folder is selected, any files within it will also be overwritten."
+msgid "When a new folder is selected, any files within it will also be overwritten."
 msgstr ""
 
-msgid "When an incoming folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed."
-msgstr ""
-
-msgid "Which files do you want to keep?"
+msgid "When a new folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed."
 msgstr ""
 
 msgid "You are currently identified as {nickname}."

--- a/lib/components/ConflictPicker/ConflictPicker.vue
+++ b/lib/components/ConflictPicker/ConflictPicker.vue
@@ -7,7 +7,8 @@
 import type { INode } from '@nextcloud/files'
 import type { ConflictInput, ConflictResolutionResult } from '../../conflict-picker.ts'
 
-import { mdiArrowRight, mdiClose } from '@mdi/js'
+import { mdiArrowRight } from '@mdi/js'
+import { basename } from '@nextcloud/paths'
 import { computed, shallowRef, useTemplateRef } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
@@ -25,9 +26,9 @@ const props = defineProps<{
 	container?: string | undefined
 
 	/**
-	 * Directory/context file name
+	 * Directory with the conflicts, its name is shown in the description
 	 */
-	dirname: string
+	dirname?: string
 
 	/**
 	 * The existing nodes (same names as the conflicts)
@@ -59,7 +60,10 @@ const blockedTitle = t('You need to select at least one version of each file to 
 const formElement = useTemplateRef('form')
 const conflictEntries = useTemplateRef('conflictEntry')
 
-const newSelected = shallowRef<ConflictInput[]>([])
+const isSingle = computed(() => props.incoming.length === 1)
+
+// Preselect the new files so the user can continue right away.
+const newSelected = shallowRef<ConflictInput[]>([...props.incoming])
 const oldSelected = shallowRef<ConflictInput[]>([])
 
 const isNoNewSelected = computed(() => newSelected.value.length === 0)
@@ -77,15 +81,49 @@ const areConflictsResolved = computed(() => {
 	return true
 })
 
-const dialogName = computed(() => props.dirname?.trim() !== ''
-	? n('%n file conflict in {dirname}', '%n file conflicts in {dirname}', props.incoming.length, { dirname: props.dirname })
-	: n('%n file conflict', '%n files conflict', props.incoming.length))
+const dialogName = computed(() => isSingle.value
+	? t('Select file to keep')
+	: t('Select files to keep'))
+
+// Only the folder name, the root folder is called "All files" in the Files app
+const folderName = computed(() => basename(props.dirname ?? '') || t('All files'))
+
+// Split on the placeholder so the folder name can be shown in bold
+const descriptionParts = computed(() => {
+	const message = isSingle.value
+		? t('An item with the same name already exists in {dirname}.')
+		: t('Items with the same name already exist in {dirname}, select which to keep.')
+	const [before, after = ''] = message.split('{dirname}')
+	return { before, after }
+})
 
 /**
  * Cancel the conflic resolution (closing the dialog)
  */
 function onCancel() {
 	emit('close', null)
+}
+
+/**
+ * Single-file: replace the existing file with the new one.
+ */
+function onReplace() {
+	emit('close', {
+		selected: [...props.incoming],
+		renamed: [],
+		skipped: [],
+	})
+}
+
+/**
+ * Single-file: keep both, the new file is uploaded with a renamed copy.
+ */
+function onKeepBoth() {
+	emit('close', {
+		selected: [],
+		renamed: [...props.incoming],
+		skipped: [],
+	})
 }
 
 /**
@@ -185,16 +223,18 @@ function onSubmit() {
 		<div :class="$style.pickerHeader">
 			<!-- Description -->
 			<p id="conflict-picker-description" :class="$style.pickerDescription">
-				{{ t('Which files do you want to keep?') }}<br>
-				{{ t('If you select both versions, the incoming file will have a number added to its name.') }}<br>
+				{{ descriptionParts.before }}<strong>{{ folderName }}</strong>{{ descriptionParts.after }}<br>
+				<template v-if="!isSingle">
+					{{ t('Existing files and folders will be deleted if not selected. If both are chosen, they will be renamed.') }}<br>
+				</template>
 				<template v-if="recursiveUpload">
-					{{ t('When an incoming folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed.') }}
+					{{ t('When a new folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed.') }}
 				</template>
 				<template v-else-if="isOverwriting">
-					{{ t('When an incoming folder is selected, any files within it will also be overwritten.') }}
+					{{ t('When a new folder is selected, any files within it will also be overwritten.') }}
 				</template>
 				<template v-else>
-					{{ t('When an incoming folder is selected, any conflicting files within it will also be overwritten.') }}
+					{{ t('When a new folder is selected, any conflicting files within it will also be overwritten.') }}
 				</template>
 			</p>
 		</div>
@@ -205,22 +245,23 @@ function onSubmit() {
 			aria-labelledby="conflict-picker-description"
 			:class="$style.pickerForm"
 			@submit.prevent.stop="onSubmit">
-			<!-- Select all checkboxes -->
-			<fieldset :class="$style.pickerSelectAll">
+			<!-- Column headings / select all checkboxes (only useful with multiple files) -->
+			<fieldset v-if="!isSingle" :class="$style.pickerSelectAll">
 				<legend class="hidden-visually">
 					{{ t('Select all checkboxes') }}
 				</legend>
 				<NcCheckboxRadioSwitch
-					:modelValue="areAllNewSelected"
-					:indeterminate="areSomeNewSelected"
-					@update:modelValue="onSelectAllNew">
-					{{ t('Select all new files') }}
-				</NcCheckboxRadioSwitch>
-				<NcCheckboxRadioSwitch
 					:modelValue="areAllOldSelected"
 					:indeterminate="areSomeOldSelected"
 					@update:modelValue="onSelectAllOld">
-					{{ t('Select all existing files') }}
+					{{ t('Existing files') }}
+				</NcCheckboxRadioSwitch>
+				<span />
+				<NcCheckboxRadioSwitch
+					:modelValue="areAllNewSelected"
+					:indeterminate="areSomeNewSelected"
+					@update:modelValue="onSelectAllNew">
+					{{ t('New files') }}
 				</NcCheckboxRadioSwitch>
 			</fieldset>
 
@@ -229,6 +270,7 @@ function onSubmit() {
 				v-for="(node, index) in existing"
 				ref="conflictEntry"
 				:key="node.fileid"
+				:isSingle="isSingle"
 				:incoming="incoming[index]!"
 				:existing="node"
 				:incomingSelected="newSelected.includes(incoming[index]!)"
@@ -245,39 +287,46 @@ function onSubmit() {
 				data-cy-conflict-picker-cancel
 				variant="tertiary"
 				@click="onCancel">
-				<template #icon>
-					<NcIconSvgWrapper :path="mdiClose" />
-				</template>
 				{{ t('Cancel') }}
 			</NcButton>
 
 			<!-- Align right -->
 			<span :class="$style.pickerActionSeparator" />
 
-			<NcButton @click="onSkipAll">
-				<template #icon>
-					<NcIconSvgWrapper :path="mdiClose" />
-				</template>
-				{{ incoming.length === 1 ? t('Skip this file') : n('Skip %n file', 'Skip %n files', incoming.length) }}
-			</NcButton>
-			<NcButton
-				:aria-disabled="!areConflictsResolved"
-				:class="[
-					$style.pickerActionSubmit,
-					{
-						[$style.pickerActionSubmit_disabled]: !areConflictsResolved,
-					},
-				]"
-				:title="areConflictsResolved ? '' : blockedTitle"
-				type="submit"
-				variant="primary"
-				@click.stop.prevent="onSubmit">
-				<template #icon>
-					<NcIconSvgWrapper directional :path="mdiArrowRight" />
-				</template>
-				{{ t('Continue') }}
-				<span v-if="!areConflictsResolved" class="hidden-visually">{{ blockedTitle }}</span>
-			</NcButton>
+			<!-- Single file: keep both or replace -->
+			<template v-if="isSingle">
+				<NcButton variant="secondary" @click="onKeepBoth">
+					{{ t('Keep both') }}
+				</NcButton>
+				<NcButton variant="primary" @click="onReplace">
+					{{ t('Replace') }}
+				</NcButton>
+			</template>
+
+			<!-- Multiple files: skip all or continue with the selection -->
+			<template v-else>
+				<NcButton @click="onSkipAll">
+					{{ n('Skip %n file', 'Skip %n files', incoming.length) }}
+				</NcButton>
+				<NcButton
+					:aria-disabled="!areConflictsResolved"
+					:class="[
+						$style.pickerActionSubmit,
+						{
+							[$style.pickerActionSubmit_disabled]: !areConflictsResolved,
+						},
+					]"
+					:title="areConflictsResolved ? '' : blockedTitle"
+					type="submit"
+					variant="primary"
+					@click.stop.prevent="onSubmit">
+					<template #icon>
+						<NcIconSvgWrapper directional :path="mdiArrowRight" />
+					</template>
+					{{ t('Continue') }}
+					<span v-if="!areConflictsResolved" class="hidden-visually">{{ blockedTitle }}</span>
+				</NcButton>
+			</template>
 		</template>
 	</NcDialog>
 </template>
@@ -286,6 +335,18 @@ function onSubmit() {
 .picker {
 	--margin: 36px;
 	--secondary-margin: 18px;
+	// shared width of the middle arrow column, so headings and entries line up
+	--arrow-column: 44px;
+
+	:global(.dialog__actions) {
+		// Match the whitespace the buttons have on the sides
+		margin-block-end: calc(var(--default-grid-baseline) * 6);
+	}
+}
+
+// Keeps the cancel button on the start side, all other actions stay at the end
+.pickerActionSeparator {
+	margin-inline-start: auto;
 }
 
 .pickerHeader {
@@ -315,11 +376,13 @@ function onSubmit() {
 	width: 100%;
 	margin-top: calc(var(--secondary-margin) * 1.5);
 	padding-bottom: var(--secondary-margin);
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 1fr var(--arrow-column) 1fr;
+	align-items: center;
 
 	legend {
 		display: flex;
 		align-items: center;
+		grid-column: 1 / -1;
 		width: 100%;
 		margin-bottom: calc(var(--secondary-margin) / 2);
 	}

--- a/lib/components/ConflictPicker/ConflictPickerCard.vue
+++ b/lib/components/ConflictPicker/ConflictPickerCard.vue
@@ -1,0 +1,142 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { mdiFile, mdiFolder } from '@mdi/js'
+import { formatFileSize } from '@nextcloud/files'
+import { computed, ref, watch } from 'vue'
+import NcDateTime from '@nextcloud/vue/components/NcDateTime'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import { t } from '../../utils/l10n.ts'
+
+const props = defineProps<{
+	/**
+	 * Preview URL, if available
+	 */
+	preview?: string
+
+	/**
+	 * Modification time, if available
+	 */
+	mtime?: Date
+
+	/**
+	 * File size in bytes, if available
+	 */
+	size?: number
+
+	/**
+	 * Whether the node is a folder (changes the fallback icon)
+	 */
+	isFolder: boolean
+
+	/**
+	 * Visually hidden label describing this side ("Existing version"/"New version").
+	 * Kept for screen readers as the column heading already labels it visually.
+	 */
+	label: string
+
+	/**
+	 * Bold the modification time (it is the more recent one)
+	 */
+	boldDate?: boolean
+
+	/**
+	 * Bold the size (it is the larger one)
+	 */
+	boldSize?: boolean
+}>()
+
+// Previews can 404, fall back to the icon instead of a broken image
+const previewFailed = ref(false)
+watch(() => props.preview, () => {
+	previewFailed.value = false
+})
+const showPreview = computed(() => !!props.preview && !previewFailed.value)
+</script>
+
+<template>
+	<span :class="$style.card">
+		<!-- Icon or preview -->
+		<NcIconSvgWrapper
+			v-if="!showPreview"
+			:class="[$style.cardIcon, { [$style.cardIcon_folder]: isFolder }]"
+			:path="isFolder ? mdiFolder : mdiFile"
+			:size="48" />
+		<img
+			v-else
+			:class="$style.cardPreview"
+			:src="preview"
+			alt=""
+			loading="lazy"
+			@error="previewFailed = true">
+
+		<!-- Description -->
+		<span :class="$style.cardDescription">
+			<NcDateTime
+				v-if="mtime"
+				:class="{ [$style.bold]: boldDate }"
+				:timestamp="mtime"
+				:relativeTime="false"
+				:format="{ timeStyle: 'short', dateStyle: 'medium' }" />
+			<span v-else>
+				{{ t('Last modified date unknown') }}
+			</span>
+			<span v-if="size !== undefined" :class="{ [$style.bold]: boldSize }">
+				{{ formatFileSize(size) }}
+			</span>
+		</span>
+
+		<span class="hidden-visually">{{ label }}</span>
+	</span>
+</template>
+
+<style module lang="scss">
+$height: 64px;
+
+.card {
+	display: flex;
+	align-items: center;
+	height: $height;
+}
+
+.cardIcon,
+.cardPreview {
+	height: $height;
+	width: $height;
+	margin: 0 var(--secondary-margin);
+	display: block;
+	flex: 0 0 $height;
+}
+
+.cardIcon {
+	color: var(--color-text-maxcontrast);
+}
+
+.cardIcon_folder {
+	color: var(--color-primary-element);
+}
+
+.cardPreview {
+	overflow: hidden;
+	border-radius: calc(var(--border-radius) * 2);
+	object-fit: cover;
+}
+
+.cardDescription {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+
+	span,
+	:deep(time) {
+		white-space: nowrap;
+	}
+}
+
+.bold {
+	font-weight: bold;
+}
+</style>

--- a/lib/components/ConflictPicker/ConflictPickerEntry.vue
+++ b/lib/components/ConflictPicker/ConflictPickerEntry.vue
@@ -7,12 +7,12 @@
 import type { INode } from '@nextcloud/files'
 import type { ConflictInput } from '../../conflict-picker.ts'
 
-import { mdiFile, mdiFolder } from '@mdi/js'
+import { mdiArrowRight } from '@mdi/js'
 import { FileType } from '@nextcloud/files'
 import { computed, ref, watch } from 'vue'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
-import NcDateTime from '@nextcloud/vue/components/NcDateTime'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import ConflictPickerCard from './ConflictPickerCard.vue'
 import { getPreviewURL } from '../../composables/preview.ts'
 import { t } from '../../utils/l10n.ts'
 
@@ -36,6 +36,12 @@ const props = defineProps<{
 	 * The new incoming node
 	 */
 	incoming: ConflictInput
+
+	/**
+	 * Single-file mode: render the two versions without checkboxes.
+	 * The parent then offers "Keep both"/"Replace" buttons instead.
+	 */
+	isSingle?: boolean
 }>()
 
 defineExpose({ validate })
@@ -67,6 +73,12 @@ const isIncomingFolder = computed(() => {
 	}
 	return props.incoming.type === FileType.Folder
 })
+
+// Bold whichever value differs to ease comparison: the newer date and the larger size.
+const incomingNewer = computed(() => !!incomingMTime.value && !!existingMTime.value && incomingMTime.value > existingMTime.value)
+const existingNewer = computed(() => !!incomingMTime.value && !!existingMTime.value && existingMTime.value > incomingMTime.value)
+const incomingLarger = computed(() => incomingSize.value !== undefined && existingSize.value !== undefined && incomingSize.value > existingSize.value)
+const existingLarger = computed(() => incomingSize.value !== undefined && existingSize.value !== undefined && existingSize.value > incomingSize.value)
 
 watch(() => props.existing, async () => {
 	existingMTime.value = getMTime(props.existing)
@@ -179,133 +191,91 @@ function validate() {
 	<fieldset :class="$style.pickerEntry">
 		<legend>{{ existing.displayname }}</legend>
 
-		<!-- Incoming file -->
+		<!-- Existing version (left) -->
 		<NcCheckboxRadioSwitch
-			v-model="incomingSelected"
-			:error="!!validationMessage"
-			:helperText="validationMessage"
-			:required="!conflictResolved">
-			<span :class="$style.pickerEntryItem">
-				<!-- Icon or preview -->
-				<NcIconSvgWrapper
-					v-if="!incomingPreview"
-					:class="[$style.pickerEntryIcon, { [$style.pickerEntryIcon_folder]: isExistingFolder }]"
-					:path="isIncomingFolder ? mdiFolder : mdiFile"
-					:size="48" />
-				<img
-					v-else
-					:class="$style.pickerEntryPreview"
-					:src="incomingPreview"
-					alt=""
-					loading="lazy">
-
-				<!-- Description -->
-				<span :class="$style.pickerEntryDescription">
-					<span>
-						{{ t('New version') }}
-					</span>
-					<NcDateTime
-						v-if="incomingMTime"
-						:timestamp="incomingMTime"
-						:relativeTime="false"
-						:format="{ timeStyle: 'short', dateStyle: 'medium' }" />
-					<span v-else>
-						{{ t('Last modified date unknown') }}
-					</span>
-					<span>
-						{{ incomingSize }}
-					</span>
-				</span>
-			</span>
-		</NcCheckboxRadioSwitch>
-
-		<!-- Existing file -->
-		<NcCheckboxRadioSwitch
+			v-if="!isSingle"
 			v-model="existingSelected"
+			:class="$style.pickerEntryColumn"
 			:error="!!validationMessage"
 			:helperText="validationMessage"
 			:required="!conflictResolved">
-			<span :class="$style.pickerEntryItem">
-				<!-- Icon or preview -->
-				<NcIconSvgWrapper
-					v-if="!existingPreview"
-					:class="[$style.pickerEntryIcon, { [$style.pickerEntryIcon_folder]: isExistingFolder }]"
-					:path="isExistingFolder ? mdiFolder : mdiFile"
-					:size="48" />
-				<img
-					v-else
-					:class="$style.pickerEntryPreview"
-					:src="existingPreview"
-					alt=""
-					loading="lazy">
-
-				<!-- Description -->
-				<span :class="$style.pickerEntryDescription">
-					<span>
-						{{ t('Existing version') }}
-					</span>
-					<NcDateTime
-						v-if="existingMTime"
-						:timestamp="existingMTime"
-						:relativeTime="false"
-						:format="{ timeStyle: 'short', dateStyle: 'medium' }" />
-					<span v-else>
-						{{ t('Last modified date unknown') }}
-					</span>
-					<span>
-						{{ existingSize }}
-					</span>
-				</span>
-			</span>
+			<ConflictPickerCard
+				:preview="existingPreview"
+				:mtime="existingMTime"
+				:size="existingSize"
+				:isFolder="isExistingFolder"
+				:label="t('Existing version')"
+				:boldDate="existingNewer"
+				:boldSize="existingLarger" />
 		</NcCheckboxRadioSwitch>
+		<ConflictPickerCard
+			v-else
+			:class="$style.pickerEntryColumn"
+			:preview="existingPreview"
+			:mtime="existingMTime"
+			:size="existingSize"
+			:isFolder="isExistingFolder"
+			:label="t('Existing version')"
+			:boldDate="existingNewer"
+			:boldSize="existingLarger" />
+
+		<!-- Arrow pointing from the existing to the new version -->
+		<NcIconSvgWrapper
+			:class="$style.pickerEntryArrow"
+			directional
+			:path="mdiArrowRight" />
+
+		<!-- New version (right) -->
+		<NcCheckboxRadioSwitch
+			v-if="!isSingle"
+			v-model="incomingSelected"
+			:class="$style.pickerEntryColumn"
+			:error="!!validationMessage"
+			:helperText="validationMessage"
+			:required="!conflictResolved">
+			<ConflictPickerCard
+				:preview="incomingPreview"
+				:mtime="incomingMTime"
+				:size="incomingSize"
+				:isFolder="isIncomingFolder"
+				:label="t('New version')"
+				:boldDate="incomingNewer"
+				:boldSize="incomingLarger" />
+		</NcCheckboxRadioSwitch>
+		<ConflictPickerCard
+			v-else
+			:class="$style.pickerEntryColumn"
+			:preview="incomingPreview"
+			:mtime="incomingMTime"
+			:size="incomingSize"
+			:isFolder="isIncomingFolder"
+			:label="t('New version')"
+			:boldDate="incomingNewer"
+			:boldSize="incomingLarger" />
 	</fieldset>
 </template>
 
 <style module lang="scss">
-$height: 64px;
-
 .pickerEntry {
+	display: grid;
+	align-items: center;
+	grid-template-columns: 1fr var(--arrow-column) 1fr;
+
 	// last fieldset does not have a border
 	&:not(:last-of-type) {
 		border-bottom: 1px solid var(--color-border);
 	}
-}
 
-.pickerEntryItem {
-	display: flex;
-	align-items: center;
-	height: $height;
-}
-
-.pickerEntryIcon,
-.pickerEntryPreview {
-	height: $height;
-	width: $height;
-	margin: 0 var(--secondary-margin);
-	display: block;
-	flex: 0 0 $height;
-}
-
-.pickerEntryIcon {
-	color: var(--color-text-maxcontrast);
-}
-
-.pickerEntryIcon_folder {
-	color: var(--color-primary-element);
-}
-
-.pickerEntryPreview {
-	overflow: hidden;
-	border-radius: calc(var(--border-radius) * 2);
-	object-fit: cover;
-}
-
-.pickerEntryDescription {
-	display: flex;
-	flex-direction: column;
-
-	span {
-		white-space: nowrap;
+	legend {
+		// span the full row above the two columns
+		grid-column: 1 / -1;
+		// the legend names the file both versions belong to
+		font-weight: bold;
 	}
+}
+
+.pickerEntryArrow {
+	justify-self: center;
+	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/lib/conflict-picker.ts
+++ b/lib/conflict-picker.ts
@@ -54,7 +54,7 @@ export interface ConflictPickerOptions {
  * Given the current content of the directory and the conflicting new nodes,
  * this will ask the user for resolving the conflicts and return the conflict resolution.
  *
- * @param dirname - The directory name with conflicts (used for the dialog title)
+ * @param dirname - The directory name with conflicts (its name is shown in the description)
  * @param conflicts - The incoming nodes
  * @param content - The current content of the directory (existing nodes)
  * @param options Optional settings for the conflict picker

--- a/tests/components/ConflictPicker.spec.ts
+++ b/tests/components/ConflictPicker.spec.ts
@@ -6,7 +6,7 @@
 import type { ConflictInput, ConflictResolutionResult } from '../../lib/conflict-picker.ts'
 
 import { File as NcFile } from '@nextcloud/files'
-import { cleanup, findByText, fireEvent, getAllByRole, getByRole, render } from '@testing-library/vue'
+import { cleanup, findByText, fireEvent, getAllByRole, getByRole, queryAllByRole, render } from '@testing-library/vue'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { afterEach, beforeAll, describe, expect, test } from 'vitest'
@@ -14,7 +14,7 @@ import ConflictPicker from '../../lib/components/ConflictPicker/ConflictPicker.v
 
 afterEach(cleanup)
 
-test('Renders default ConflictPicker', async () => {
+describe('Single file conflict', () => {
 	const oldImage = new NcFile({
 		id: 1,
 		root: '/files/user',
@@ -25,25 +25,83 @@ test('Renders default ConflictPicker', async () => {
 		mtime: new Date('2021-01-01T00:00:00.000Z'),
 	})
 
-	const image = new File([], 'image.jpg')
-	render(ConflictPicker, {
-		props: {
-			container: getContainer(),
-			dirname: 'Pictures',
-			existing: [oldImage],
-			incoming: [image],
-		},
+	test('Renders without checkboxes and with keep both / replace buttons', async () => {
+		const image = new File([], 'image.jpg')
+		render(ConflictPicker, {
+			props: {
+				container: getContainer(),
+				dirname: 'Pictures',
+				existing: [oldImage],
+				incoming: [image],
+			},
+		})
+
+		const dialog = getByRole(document.body, 'dialog', { name: 'Select file to keep' })
+		expect(dialog).toBeInstanceOf(HTMLElement)
+
+		// No checkboxes for a single file
+		expect(queryAllByRole(dialog, 'checkbox')).toHaveLength(0)
+
+		expect(getByRole(dialog, 'button', { name: 'Cancel' })).toBeInstanceOf(HTMLElement)
+		expect(getByRole(dialog, 'button', { name: 'Keep both' })).toBeInstanceOf(HTMLElement)
+		expect(getByRole(dialog, 'button', { name: 'Replace' })).toBeInstanceOf(HTMLElement)
 	})
 
-	const dialog = getByRole(document.body, 'dialog')
-	expect(dialog).toBeInstanceOf(HTMLElement)
-	expect(getByRole(document.body, 'dialog', { name: /1 file conflict in Pictures/ })).toBeInstanceOf(HTMLElement)
+	test('Shows only the folder name, the root is called "All files"', async () => {
+		const image = new File([], 'image.jpg')
+		const props = {
+			container: getContainer(),
+			existing: [oldImage],
+			incoming: [image],
+		}
 
-	expect(getByRole(dialog, 'form')).toBeInstanceOf(HTMLElement)
-	expect(getAllByRole(dialog, 'checkbox')).toHaveLength(4)
+		const component = render(ConflictPicker, { props: { ...props, dirname: '/Photos/Sub folder' } })
+		const dialog = getByRole(document.body, 'dialog')
+		expect(dialog.querySelector('strong')!.textContent).toBe('Sub folder')
 
-	expect(getByRole(dialog, 'checkbox', { name: 'Select all new files' })).toBeInstanceOf(HTMLElement)
-	expect(getByRole(dialog, 'checkbox', { name: 'Select all existing files' })).toBeInstanceOf(HTMLElement)
+		await component.rerender({ ...props, dirname: '/' })
+		expect(dialog.querySelector('strong')!.textContent).toBe('All files')
+	})
+
+	test('Replace keeps only the new file', async () => {
+		const image = new File([], 'image.jpg')
+		const component = render(ConflictPicker, {
+			props: {
+				container: getContainer(),
+				dirname: 'Pictures',
+				existing: [oldImage],
+				incoming: [image],
+			},
+		})
+
+		const dialog = getByRole(document.body, 'dialog')
+		await fireEvent(getByRole(dialog, 'button', { name: 'Replace' }), new MouseEvent('click', { bubbles: true }))
+
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
+		expect(result.selected).toEqual([image])
+		expect(result.renamed).toHaveLength(0)
+		expect(result.skipped).toHaveLength(0)
+	})
+
+	test('Keep both renames the new file', async () => {
+		const image = new File([], 'image.jpg')
+		const component = render(ConflictPicker, {
+			props: {
+				container: getContainer(),
+				dirname: 'Pictures',
+				existing: [oldImage],
+				incoming: [image],
+			},
+		})
+
+		const dialog = getByRole(document.body, 'dialog')
+		await fireEvent(getByRole(dialog, 'button', { name: 'Keep both' }), new MouseEvent('click', { bubbles: true }))
+
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
+		expect(result.renamed).toEqual([image])
+		expect(result.selected).toHaveLength(0)
+		expect(result.skipped).toHaveLength(0)
+	})
 })
 
 describe('ConflictPicker resolving', () => {
@@ -109,7 +167,7 @@ describe('ConflictPicker resolving', () => {
 		await expect(findByText(dialog, /folder is selected, the content is written into the existing folder/)).resolves.not.toThrow()
 	})
 
-	test('Pick all incoming files', async () => {
+	test('New files are preselected so the user can continue right away', async () => {
 		const component = render(ConflictPicker, {
 			props: {
 				container: getContainer(),
@@ -120,34 +178,22 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
-		const checkbox: HTMLInputElement = getByRole(dialog, 'checkbox', { name: /Select all new files/ })
-		expect(checkbox.checked).toBe(false)
+		const selectAllNew: HTMLInputElement = getByRole(dialog, 'checkbox', { name: 'New files' })
+		expect(selectAllNew.checked).toBe(true)
 
 		const individualCheckboxes: HTMLInputElement[] = getAllByRole(dialog, 'checkbox', { name: /New version/ })
 		expect(individualCheckboxes).toHaveLength(2)
-		for (const box of individualCheckboxes) {
-			expect(box.checked).toBe(false)
-		}
-
-		await fireEvent(checkbox, new MouseEvent('click', { bubbles: true }))
-		expect(checkbox.checked).toBe(true)
 		for (const box of individualCheckboxes) {
 			expect(box.checked).toBe(true)
 		}
 
 		const submit = getByRole(dialog, 'button', { name: 'Continue' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
 		expect(result.renamed).toHaveLength(0)
 		expect(result.skipped).toHaveLength(0)
-		expect(result.selected).toHaveLength(2)
 		expect(result.selected).toEqual([...images])
 	})
 
@@ -162,34 +208,20 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
-		const checkbox: HTMLInputElement = getByRole(dialog, 'checkbox', { name: /Select all existing files/ })
-		expect(checkbox.checked).toBe(false)
+		const selectAllNew: HTMLInputElement = getByRole(dialog, 'checkbox', { name: 'New files' })
+		const selectAllExisting: HTMLInputElement = getByRole(dialog, 'checkbox', { name: 'Existing files' })
 
-		const individualCheckboxes: HTMLInputElement[] = getAllByRole(dialog, 'checkbox', { name: /Existing version/ })
-		expect(individualCheckboxes).toHaveLength(2)
-		for (const box of individualCheckboxes) {
-			expect(box.checked).toBe(false)
-		}
-
-		await fireEvent(checkbox, new MouseEvent('click', { bubbles: true }))
-		expect(checkbox.checked).toBe(true)
-		for (const box of individualCheckboxes) {
-			expect(box.checked).toBe(true)
-		}
+		// Deselect the (preselected) new files and select the existing ones instead
+		await fireEvent(selectAllNew, new MouseEvent('click', { bubbles: true }))
+		await fireEvent(selectAllExisting, new MouseEvent('click', { bubbles: true }))
 
 		const submit = getByRole(dialog, 'button', { name: 'Continue' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
 		expect(result.renamed).toHaveLength(0)
 		expect(result.selected).toHaveLength(0)
-		expect(result.skipped).toHaveLength(2)
 		expect(result.skipped).toEqual([...images])
 	})
 
@@ -204,33 +236,17 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
-		const checkbox1: HTMLInputElement = getByRole(dialog, 'checkbox', { name: /Select all existing files/ })
-		const checkbox2: HTMLInputElement = getByRole(dialog, 'checkbox', { name: /Select all new files/ })
-		const individualCheckboxes: HTMLInputElement[] = getAllByRole(dialog, 'checkbox', { name: /(Existing|New) version/ })
-		expect(individualCheckboxes).toHaveLength(4)
-		for (const box of individualCheckboxes) {
-			expect(box.checked).toBe(false)
-		}
-
-		await fireEvent(checkbox1, new MouseEvent('click', { bubbles: true }))
-		await fireEvent(checkbox2, new MouseEvent('click', { bubbles: true }))
-		for (const box of individualCheckboxes) {
-			expect(box.checked).toBe(true)
-		}
+		// New files are preselected, additionally select the existing ones
+		const selectAllExisting: HTMLInputElement = getByRole(dialog, 'checkbox', { name: 'Existing files' })
+		await fireEvent(selectAllExisting, new MouseEvent('click', { bubbles: true }))
 
 		const submit = getByRole(dialog, 'button', { name: 'Continue' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
 		expect(result.selected).toHaveLength(0)
 		expect(result.skipped).toHaveLength(0)
-		expect(result.renamed).toHaveLength(2)
 		expect(result.renamed).toEqual([...images])
 	})
 
@@ -245,28 +261,20 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
 		const group1 = getByRole(dialog, 'group', { name: 'image1.jpg' })
-		const group2 = getByRole(dialog, 'group', { name: 'image2.jpg' })
-		const existing: HTMLInputElement = getByRole(group1, 'checkbox', { name: /Existing version/ })
-		const incoming: HTMLInputElement = getByRole(group2, 'checkbox', { name: /New version/ })
-		expect(existing.checked).toBe(false)
-		expect(incoming.checked).toBe(false)
+		const existing1: HTMLInputElement = getByRole(group1, 'checkbox', { name: /Existing version/ })
+		const incoming1: HTMLInputElement = getByRole(group1, 'checkbox', { name: /New version/ })
 
-		await fireEvent(existing, new MouseEvent('click', { bubbles: true }))
-		await fireEvent(incoming, new MouseEvent('click', { bubbles: true }))
-		expect(existing.checked).toBe(true)
-		expect(incoming.checked).toBe(true)
+		// For image1 keep the existing file instead of the (preselected) new one
+		await fireEvent(incoming1, new MouseEvent('click', { bubbles: true }))
+		await fireEvent(existing1, new MouseEvent('click', { bubbles: true }))
+		// image2 keeps its preselected new file
 
 		const submit = getByRole(dialog, 'button', { name: 'Continue' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<File>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<File>]
 		expect(result.renamed).toHaveLength(0)
 		expect(result.skipped).toHaveLength(1)
 		expect(result.skipped[0]!.name).toBe('image1.jpg')
@@ -285,16 +293,11 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
 		const submit = getByRole(dialog, 'button', { name: 'Skip 2 files' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput>]
 		expect(result.renamed).toHaveLength(0)
 		expect(result.selected).toHaveLength(0)
 		expect(result.skipped).toHaveLength(2)
@@ -312,16 +315,11 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
 		const submit = getByRole(dialog, 'button', { name: 'Cancel' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput> | null]
 		expect(result).toBeNull()
 	})
 
@@ -336,16 +334,11 @@ describe('ConflictPicker resolving', () => {
 		})
 
 		const dialog = getByRole(document.body, 'dialog')
-		expect(dialog).toBeInstanceOf(HTMLElement)
 
 		const submit = getByRole(dialog, 'button', { name: 'Close' })
-		expect(submit).toBeInstanceOf(HTMLButtonElement)
 		await fireEvent(submit, new MouseEvent('click', { bubbles: true }))
 
-		const events: [ConflictResolutionResult<ConflictInput>][] = component.emitted('close')
-		expect(events).toHaveLength(1)
-		const [result] = events[0]!
-
+		const [result] = component.emitted('close')[0]! as [ConflictResolutionResult<ConflictInput> | null]
 		expect(result).toBeNull()
 	})
 })


### PR DESCRIPTION
Same as https://github.com/nextcloud-libraries/nextcloud-upload/pull/2151

Our current file conflict dialog (when you upload the same file again) immediately jumps into a very complex "pick files" view.

Based on a mockup by @kra-mo and some discussions.

The improvements:
- "Existing version" has been moved to the left and "New version" to the right. This is swapped from the previous layout as that was confusing – new things are usually on the right.
- The flow for 1 file was simplified by removing the checkboxes altogether, and just going for buttons "Keep both" and "Replace".
- For multiple files, the newer files are all preselected by default. That way people can click "Continue" directly.
- The wording is simplified
- To more easily compare what’s new or what changed between existing and new, whichever date is newer is bolded, and whichever size is larger is bolded.
- A little arrow inbetween each of the versions pointing right from the existing file to the new file helps with visual clarity.
- The icons of the cancel and skip buttons were removed to reduce visual noise.

We could probably simplify the wording even more for the multiple files case, but this PR is also quite big already. :) 


Before|After
-|-
<img width="1000" height="600" alt="before-single" src="https://github.com/user-attachments/assets/9bd31191-c736-44b0-b5f2-942de63c0e47" />|<img width="1000" height="600" alt="single" src="https://github.com/user-attachments/assets/94299129-0a5e-4b96-a8bd-be7bf0df73c9" />
<img width="1000" height="600" alt="before-multiple" src="https://github.com/user-attachments/assets/f9e3d3ca-113f-47ca-89cb-d28ddeed0915" />|<img width="1000" height="600" alt="multiple" src="https://github.com/user-attachments/assets/a5626928-bedf-4dfc-82eb-d68642791a54" />




### Mockup by @kra-mo for reference

<img width="716" height="328" alt="20260723_122436" src="https://github.com/user-attachments/assets/3bf9893a-6e10-40fb-a729-ab54a2e5ed69" />




## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI